### PR TITLE
first attempts at supporting v0.12

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,9 @@
       'include_dirs': [
         '<!(node -e "require(\'nan\')")',
         '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "src"))\')',
-        '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "deps", "v8", "src"))\')'
+        '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "deps", "v8"))\')',
+        '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "deps", "v8", "src"))\')',
+        '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "deps", "v8", "src", "base"))\')'
       ]
     },
     {
@@ -19,7 +21,9 @@
       'include_dirs': [
         '<!(node -e "require(\'nan\')")',
         '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "src"))\')',
-        '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "deps", "v8", "src"))\')'
+        '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "deps", "v8"))\')',
+        '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "deps", "v8", "src"))\')',
+        '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "deps", "v8", "src", "base"))\')'
       ]
     },
     {
@@ -30,7 +34,9 @@
       'include_dirs': [
         '<!(node -e "require(\'nan\')")',
         '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "src"))\')',
-        '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "deps", "v8", "src"))\')'
+        '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "deps", "v8"))\')',
+        '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "deps", "v8", "src"))\')',
+        '<!(node -e \'console.log(require("path").join(process.env.HOME, ".node-gyp", process.versions.node, "deps", "v8", "src", "base"))\')'
       ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/thlorenz/v8-flags",
   "dependencies": {
-    "nan": "~1.2.0"
+    "nan": "~1.6.0"
   },
   "devDependencies": {
     "doctoc": "~0.7.1",


### PR DESCRIPTION
So this doesn't work with Node v0.12 - I've made attempts at fixing but out of my depth in C++ (willing to learn though!). 

So it seems the first step would be to upgrade nan to 1.6 - this actually works great (with some deprecation warnings.)

The next problem was atomicops.h - in v8 3.27 (node  v0.12 is on v8 3.28) 
this was relocated to deps/v8/src/base, and then atomicops.h is expecting deps/v8.

So that's why extra paths are added to bindings.gyp.

Then I hit these errors:

``` sh
In file included from ../src/v8_flags.cc:111:
../src/v8_flag_definitions.h:4:1: error: C++ requires a type specifier for all declarations
DEFINE_BOOL(use_strict, false, "enforce strict mode")
^~~~~~~~~~~
../src/v8_flag_definitions.h:4:13: error: use of undeclared identifier 'use_strict'
DEFINE_BOOL(use_strict, false, "enforce strict mode")
            ^
../src/v8_flag_definitions.h:4:54: error: expected ';' after top level declarator
DEFINE_BOOL(use_strict, false, "enforce strict mode")
```

And now I do not know what to do...

I notice scripts/preinstall.js performs some pre-processing on the flags definition file... 

Maybe there's been a refactor of v8_flag_definitions.h  ... 

... help?
